### PR TITLE
If group membership doesn't match, return PAM_IGNORE

### DIFF
--- a/pam_duo/pam_duo.c
+++ b/pam_duo/pam_duo.c
@@ -180,7 +180,8 @@ pam_sm_authenticate(pam_handle_t *pamh, int pam_flags,
     if (matched == -1) {
         return (PAM_SERVICE_ERR);
     } else if (matched == 0) {
-        return (PAM_SUCCESS);
+	/* If user not in a Duo group, ignore the pam_duo module */
+        return (PAM_IGNORE);
     }
 
     /* Grab the remote host */


### PR DESCRIPTION
Seems safer to return IGNORE if group membership doesn't match, rather than success. Otherwise certain PAM configurations could allow logins that shouldn't otherwise occur.
